### PR TITLE
Register layouts with ibus

### DIFF
--- a/linux/register-neolight.sh
+++ b/linux/register-neolight.sh
@@ -3,15 +3,34 @@ set -euo pipefail
 
 # Based on https://aur.archlinux.org/packages/us_da-layout/
 
-rules=/usr/share/X11/xkb/rules
-cd "$rules"
+evdev_rules=/usr/share/X11/xkb/rules
+evdev_xml=$evdev_rules/evdev.xml
+evdev=$evdev_rules/evdev
+ibus_file=/usr/share/ibus/component/simple.xml
 
+set_permissions_and_move() {
+	tmp_file="$1"
+	dest_file="$2"
+	chown --reference="$dest_file" "$tmp_file"
+	chmod --reference="$dest_file" "$tmp_file"
+	mv "$tmp_file" "$dest_file"
+}
 
 register() {
-	if grep neolight evdev.xml > /dev/null; then
-		echo "Neolight already found in $rules/evdev.xml"
+	register_evdev
+	register_ibus
+}
+
+unregister() {
+	unregister_evdev
+	unregister_ibus
+}
+
+register_evdev() {
+	if grep -q neolight "$evdev_xml"; then
+		echo "Neolight already found in $evdev_xml"
 	else
-		echo "Adding neolight to $rules/evdev.xml"
+		echo "Adding neolight to $evdev_xml"
 		read -r -d '' layout <<-EOF || true
 		<!-- BEGIN neolight -->
 		    <layout>
@@ -34,15 +53,23 @@ register() {
 		    </layout>
 		<!-- END neolight -->
 		EOF
-		awk -v layout="$layout" '{ print } /<layoutList>/ { print layout }' evdev.xml > tmp && mv tmp evdev.xml
+
+		evdev_xml_tmp="$(mktemp)"
+		awk -v layout="$layout" \
+			'{ print }
+			/<layoutList>/ { print layout }' \
+			"$evdev_xml" > "$evdev_xml_tmp" \
+		&& set_permissions_and_move "$evdev_xml_tmp" "$evdev_xml"
 	fi
 
 
-	if grep neolight evdev > /dev/null; then
-		echo "Neolight already found in $rules/evdev"
+	if grep -q neolight "$evdev"; then
+		echo "Neolight already found in $evdev"
 	else
-		echo "Adding neolight to $rules/evdev"
-		cat <<-EOF >> evdev
+		echo "Adding neolight to $evdev"
+		evdev_tmp="$(mktemp)"
+                cat "$evdev" > "$evdev_tmp" || true
+                cat <<-EOF >> "$evdev_tmp"
 		// BEGIN neolight
 		! option   = symbols
 		  neolight = +neolight(layers)
@@ -50,13 +77,82 @@ register() {
 		  neolight:jp = +neolight(jp)
 		// END neolight
 		EOF
+
+		set_permissions_and_move "$evdev_tmp" "$evdev"
 	fi
 }
 
+unregister_evdev() {
+	evdev_xml_tmp="$(mktemp)"
+	awk \
+		'BEGIN { f=1 }
+		/BEGIN neolight/ { f=0 }
+		/END neolight/ { f=1; next }
+		f' \
+		"$evdev_xml" > "$evdev_xml_tmp" \
+	&& set_permissions_and_move "$evdev_xml_tmp" "$evdev_xml"
 
-unregister() {
-	awk 'BEGIN { f=1 } /BEGIN neolight/ { f=0 } /END neolight/ { f=1; next } f' evdev.xml > tmp && mv tmp evdev.xml
-	awk 'BEGIN { f=1 } /BEGIN neolight/ { f=0 } /END neolight/ { f=1; next } f' evdev > tmp && mv tmp evdev
+	evdev_tmp="$(mktemp)"
+	awk \
+		'BEGIN { f=1 }
+		/BEGIN neolight/ { f=0 }
+		/END neolight/ { f=1; next }
+		f' \
+		"$evdev" > "$evdev_tmp" \
+	&& set_permissions_and_move "$evdev_tmp" "$evdev"
+}
+
+register_ibus() {
+	if grep -q neolight "$ibus_file"; then
+		echo "Neolight already found in $ibus_file"
+	else
+		echo "Adding neolight to $ibus_file"
+		read -r -d '' engines <<-EOF || true
+		<!-- BEGIN neolight -->
+		        <engine>
+		            <name>xkb:de:neolight:deu</name>
+		            <language>de</language>
+		            <license></license>
+		            <author></author>
+		            <layout>neolight</layout>
+		            <longname>German (Neolight)</longname>
+		            <description>German (Neolight)</description>
+		            <icon>ibus-keyboard</icon>
+		            <rank>1</rank>
+		        </engine>
+		        <engine>
+		            <name>xkb:de:neolight_escape_keys:deu</name>
+		            <language>de</language>
+		            <license></license>
+		            <author></author>
+		            <layout>neolight</layout>
+		            <layout_variant>de_escape_keys</layout_variant>
+		            <longname>German (Neolight, additional escape keys)</longname>
+		            <description>German (Neolight, additional escape keys)</description>
+		            <icon>ibus-keyboard</icon>
+		            <rank>1</rank>
+		        </engine>
+		<!-- END neolight -->
+		EOF
+
+		ibus_tmp="$(mktemp)"
+		awk -v engines="$engines" \
+			'{ print }
+			/<engines>/ { print engines }' \
+			"$ibus_file" > "$ibus_tmp" \
+		&& set_permissions_and_move "$ibus_tmp" "$ibus_file"
+	fi
+}
+
+unregister_ibus() {
+	ibus_tmp="$(mktemp)"
+	awk \
+		'BEGIN { f=1 }
+		/BEGIN neolight/ { f=0 }
+		/END neolight/ { f=1; next }
+		f' \
+		"$ibus_file" > "$ibus_tmp" \
+	&& set_permissions_and_move "$ibus_tmp" "$ibus_file"
 }
 
 

--- a/linux/register-neolight.sh
+++ b/linux/register-neolight.sh
@@ -103,7 +103,10 @@ unregister_evdev() {
 }
 
 register_ibus() {
-	if grep -q neolight "$ibus_file"; then
+	if [[ ! -f "$ibus_file" ]]; then
+		echo "No ibus file found. Skipping."
+		return
+	elif grep -q neolight "$ibus_file"; then
 		echo "Neolight already found in $ibus_file"
 	else
 		echo "Adding neolight to $ibus_file"
@@ -145,6 +148,9 @@ register_ibus() {
 }
 
 unregister_ibus() {
+	[[ ! -f "$ibus_file" ]] \
+		&& return
+
 	ibus_tmp="$(mktemp)"
 	awk \
 		'BEGIN { f=1 }


### PR DESCRIPTION
Ibus did not recognise the neolayout and it could not get picked through
`ibus-setup`. I also noticed potential unatomic changes and a potential
change in permissions.

This adds a register and unregister function to to
`linux/register-neolight.sh`. The script had to be rewritten quite a bit
since it assumed the only changes necessary had to be made in a single
directory. There are now two register functions one for evdev (the
register function before the change) and one for ibus which both use
absolute paths instead of relative ones – same for unregister.

When using redirection the umask of the current user is being used and
the owner and group is being set to the current user. This might lead to
owner, group and permissions changing. This has been fixed through using
the function `set_permissions_and_move` by creating all changes in a
temporary file, copying permissions, etc. and moving the changed file to
the original location. This has also been done for the file `evdev`
which previously was modified unatomically.